### PR TITLE
Give debugger buttons little more space

### DIFF
--- a/app/styles/debugger/debugger.css
+++ b/app/styles/debugger/debugger.css
@@ -45,7 +45,7 @@
 
 .debug-container {
     position: absolute;
-    top: 20px;
+    top: 25px;
     right: 0px;
     bottom: 0px;
     left: 0px;


### PR DESCRIPTION
Otherwise event list seems to collide with buttons upon scrolling