### PR TITLE
Enable snapshot publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,27 +3,18 @@ jobs:
   build:
     working_directory: ~/cafienne-ide
     docker:
-      - image: circleci/node:10.9.0
+      - image: cimg/node:8.17.0
     steps:
       - checkout
       - run:
           name: Giving permissions
           command: sudo chmod -R 777 ./
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ checksum "package.json" }}
-            # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
       - run:
           name: Installing dependencies
           command: |
             npm install
             sudo npm install bower -g
             bower install
-      - save_cache:
-          paths:
-            - node_modules
-          key: v1-dependencies-{{ checksum "package.json" }}
       - setup_remote_docker:
           version: 19.03.13
           docker_layer_caching: true
@@ -45,7 +36,7 @@ jobs:
   build for release:
     working_directory: ~/cafienne-ide
     docker:
-      - image: circleci/node:10.9.0
+      - image: cimg/node:8.17.0
     steps:
       - checkout
       - run:
@@ -58,21 +49,12 @@ jobs:
             cat ./version.txt
             TAG=$(cat ./version.txt)
             printenv
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ checksum "package.json" }}
-            # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
       - run:
           name: Installing dependencies
           command: |
             npm install
             sudo npm install bower -g
             bower install
-      - save_cache:
-          paths:
-            - node_modules
-          key: v1-dependencies-{{ checksum "package.json" }}
       - setup_remote_docker:
           docker_layer_caching: false
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,16 +21,25 @@ jobs:
       - run:
           name: Build docker image
           command: |
-            docker build -t cafienne/ide:latest .
-      - run:
-          name: Push docker image
-          command: |
             if [ "${CIRCLE_BRANCH}" == "main" ];
             then
               echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
+              docker build -t cafienne/ide:latest .
+            else
+              echo "Building docker image cafienne/ide:snapshot"
+              docker build -t cafienne/ide:snapshot .
+            fi
+      - run:
+          name: Push docker image
+          command: |
+            echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
+            if [ "${CIRCLE_BRANCH}" == "main" ];
+            then
+              echo "Publishing image 'cafienne/ide:latest' to docker hub"
               docker push cafienne/ide:latest
             else
-              echo "Not pushing image to docker hub"
+              echo "Publishing image 'cafienne/ide:snapshot' to docker hub"
+              docker push cafienne/ide:snapshot
             fi
 
   build for release:


### PR DESCRIPTION
This commit enables publishing branch commits to docker with the tag `snapshot` and through that it is possible to test a published docker image on that branch