### PR TITLE
Bump mout and wiredep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1026,32 +1026,24 @@
       }
     },
     "bower-config": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/bower-config/-/bower-config-0.5.3.tgz",
-      "integrity": "sha512-Ly0EwAJGD5fX7y7vSvgo+yKPh+oME9jYd5Npqecxs5izpjV8aMZGF3j1ZhDDOCBIFDVNk+gGmKZAFAPmr86jLQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/bower-config/-/bower-config-1.4.3.tgz",
+      "integrity": "sha512-MVyyUk3d1S7d2cl6YISViwJBc2VXCkxF5AUFykvN0PQj5FsUiMNSgAYTso18oRFfyZ6XEtjrgg9MAaufHbOwNw==",
       "dev": true,
       "requires": {
-        "graceful-fs": "~2.0.0",
-        "mout": "~0.9.0",
-        "optimist": "~0.6.0",
-        "osenv": "0.0.3"
+        "graceful-fs": "^4.1.3",
+        "minimist": "^0.2.1",
+        "mout": "^1.0.0",
+        "osenv": "^0.1.3",
+        "untildify": "^2.1.0",
+        "wordwrap": "^0.0.3"
       },
       "dependencies": {
-        "graceful-fs": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
-          "integrity": "sha512-hcj/NTUWv+C3MbqrVb9F+aH6lvTwEHJdx2foBxlrVq5h6zE8Bfu4pv4CAAqbDcZrw/9Ak5lsRXlY9Ao8/F0Tuw==",
+        "minimist": {
+          "version": "0.2.2",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.2.2.tgz",
+          "integrity": "sha512-g92kDfAOAszDRtHNagjZPPI/9lfOFaRBL/Ud6Z0RKZua/x+49awTydZLh5Gkhb80Xy5hmcvZNLGzscW5n5yd0g==",
           "dev": true
-        },
-        "optimist": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-          "integrity": "sha512-snN4O4TkigujZphWLN0E//nQmm7790RYaE53DdL7ZYwee2D8DDo9/EyYiKUfN3rneWUjhJnueija3G9I2i0h3g==",
-          "dev": true,
-          "requires": {
-            "minimist": "~0.0.1",
-            "wordwrap": "~0.0.2"
-          }
         }
       }
     },
@@ -1287,7 +1279,7 @@
         },
         "http-errors": {
           "version": "1.6.3",
-          "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
           "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
           "dev": true,
           "requires": {
@@ -8923,9 +8915,9 @@
       }
     },
     "mout": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/mout/-/mout-0.9.1.tgz",
-      "integrity": "sha512-mZMABHAQPQ87JDQuxZIndS6XXDYZfeAfcTvHYyEFG4SEUiGNkInNZi/WhesQjCKUWih1bDDkqHw63wyCaczhsw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/mout/-/mout-1.2.4.tgz",
+      "integrity": "sha512-mZb9uOruMWgn/fw28DG4/yE3Kehfk1zKCLhuDU2O3vlKdnBBr4XaOCqVTflJ5aODavGUPqFHZgrFX3NJVuxGhQ==",
       "dev": true
     },
     "ms": {
@@ -9326,7 +9318,7 @@
     },
     "opn": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/opn/-/opn-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/opn/-/opn-1.0.2.tgz",
       "integrity": "sha1-uQlkM0bQChq8l3qLlvPOPFPVz18=",
       "dev": true
     },
@@ -9424,10 +9416,14 @@
       "dev": true
     },
     "osenv": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.0.3.tgz",
-      "integrity": "sha512-VBk1bfdaO4gh3OWO8LBuDY2alp0buL8YzQ6t13xyc8PQPrnUg5AgQvINQx3UkS4dom8UGCL597q4Y2+M4TPvmw==",
-      "dev": true
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+      "dev": true,
+      "requires": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
+      }
     },
     "output-file-sync": {
       "version": "1.1.2",
@@ -10632,7 +10628,7 @@
         },
         "http-errors": {
           "version": "1.6.3",
-          "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
           "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
           "dev": true,
           "requires": {
@@ -12079,6 +12075,15 @@
         }
       }
     },
+    "untildify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
+      "integrity": "sha512-sJjbDp2GodvkB0FZZcn7k6afVisqX5BZD7Yq3xp4nN2O15BBK0cLm3Vwn2vQaF7UDS0UUsrQMkkplmDI5fskig==",
+      "dev": true,
+      "requires": {
+        "os-homedir": "^1.0.0"
+      }
+    },
     "unzip-response": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
@@ -12569,135 +12574,60 @@
       "integrity": "sha512-1pTPQDKTdd61ozlKGNCjhNRd+KPmgLSGa3mZTHoOliaGcESD8G1PXhh7c1fgiPjVbNVfgy2Faw4BI8/m0cC8Mg=="
     },
     "wiredep": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/wiredep/-/wiredep-2.2.2.tgz",
-      "integrity": "sha512-bv2Jt/2W+cgi4OELKN6RXjIzk1rFvIOm4PK6PX54F8mc9+ajIiqoT/FrXjFN6lhfIpm2h4vRTP4X/beGWOeHiA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/wiredep/-/wiredep-4.0.0.tgz",
+      "integrity": "sha512-w4QDvO5bgcpOBHFBCEH4oKKcMBTeG2pMEzkLSAhjKZ0X6+yb1dAS3vUEtjjz6Rg1M3ox3PG6BSCFZJEQh+TF8w==",
       "dev": true,
       "requires": {
-        "bower-config": "^0.5.0",
-        "chalk": "^0.5.1",
-        "glob": "^4.0.5",
-        "lodash": "^2.4.1",
-        "minimist": "^1.1.0",
+        "bower-config": "^1.3.0",
+        "glob": "^7.0.3",
+        "lodash": "^4.6.1",
         "propprop": "^0.3.0",
-        "through2": "^0.6.1"
+        "through2": "^2.0.1",
+        "wiredep-cli": "^0.1.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
-          "integrity": "sha512-sGwIGMjhYdW26/IhwK2gkWWI8DRCVO6uj3hYgHT+zD+QL1pa37tM3ujhyfcJIYSbsxp7Gxhy7zrRW/1AHm4BmA==",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
-          "integrity": "sha512-f2PKUkN5QngiSemowa6Mrk9MPCdtFiOSmibjZ+j1qhLGHHYsqZwmBMRF3IRMVXo8sybDqx2fJl2d/8OphBoWkA==",
-          "dev": true
-        },
-        "chalk": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-          "integrity": "sha512-bIKA54hP8iZhyDT81TOsJiQvR1gW+ZYSXFaZUAvoD4wCHdbHY2actmpTE4x344ZlFqHbvoxKOaESULTZN2gstg==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^1.1.0",
-            "escape-string-regexp": "^1.0.0",
-            "has-ansi": "^0.1.0",
-            "strip-ansi": "^0.3.0",
-            "supports-color": "^0.2.0"
-          }
-        },
         "glob": {
-          "version": "4.5.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-          "integrity": "sha512-I0rTWUKSZKxPSIAIaqhSXTM/DiII6wame+rEC3cFA5Lqmr9YmdL7z6Hj9+bdWtTvoY1Su4/OiMLmb37Y7JzvJQ==",
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
           "dev": true,
           "requires": {
+            "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
             "inherits": "2",
-            "minimatch": "^2.0.1",
-            "once": "^1.3.0"
+            "minimatch": "^3.1.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
-        },
-        "has-ansi": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-          "integrity": "sha512-1YsTg1fk2/6JToQhtZkArMkurq8UoWU1Qe0aR3VUHjgij4nOylSWLWAtBXoZ4/dXOmugfLGm1c+QhuD0JyedFA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^0.2.0"
-          }
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "lodash": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-          "integrity": "sha512-Kak1hi6/hYHGVPmdyiZijoQyz5x2iGVzs6w9GYB/HiXEtylY7tIoYEROMjvM1d9nXJqPOrG2MNPMn01bJ+S0Rw==",
-          "dev": true
         },
         "minimatch": {
-          "version": "2.0.10",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-          "integrity": "sha512-jQo6o1qSVLEWaw3l+bwYA2X0uLuK2KjNh2wjgO7Q/9UJnXr1Q3yQKR8BI0/Bt/rPg75e6SMW4hW/6cBHVTZUjA==",
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.0.0"
+            "brace-expansion": "^1.1.7"
           }
-        },
+        }
+      }
+    },
+    "wiredep-cli": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wiredep-cli/-/wiredep-cli-0.1.0.tgz",
+      "integrity": "sha512-Gayaqg8UXk5qPH0MuVP35m7h9GvvCE8XJd1AeXOFgjHxxowhjyfeKSd4BNBsbPAy5kRQ1c5A4tJKcNV8LiE6jw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.1",
+        "minimist": "^1.1.0",
+        "wiredep": "*"
+      },
+      "dependencies": {
         "minimist": {
-          "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "version": "1.2.7",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+          "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
           "dev": true
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-          "integrity": "sha512-DerhZL7j6i6/nEnVG0qViKXI0OKouvvpsAiaj7c+LfqZZZxdwZtv8+UiA/w4VUJpT8UzX0pR1dcHOii1GbmruQ==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^0.2.1"
-          }
-        },
-        "supports-color": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
-          "integrity": "sha512-tdCZ28MnM7k7cJDJc7Eq80A9CsRFAAOZUy41npOZCs++qSjfIy7o5Rh46CBk+Dk5FbKJ33X3Tqg4YrV07N5RaA==",
-          "dev": true
-        },
-        "through2": {
-          "version": "0.6.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "integrity": "sha512-RkK/CCESdTKQZHdmKICijdKKsCRVHs5KsLZ6pACAmF/1GPUQhonHSXWNERctxEp7RmvjdNbZTL5z9V7nSCXKcg==",
-          "dev": true,
-          "requires": {
-            "readable-stream": ">=1.0.33-1 <1.1.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
-          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "gulp-useref": "^1.1.1",
     "main-bower-files": "^2.5.0",
     "opn": "^1.0.1",
-    "wiredep": "^2.2.2"
+    "wiredep": "^4.0.0"
   },
   "scripts": {
     "deploy": "node server/repository/repository_cli.js deploy",


### PR DESCRIPTION
Bumps [mout](https://github.com/mout/mout) to 1.2.4 and updates ancestor dependency [wiredep](https://github.com/taptapship/wiredep). These dependencies need to be updated together.


Updates `mout` from 0.9.1 to 1.2.4
- [Release notes](https://github.com/mout/mout/releases)
- [Changelog](https://github.com/mout/mout/blob/master/CHANGELOG.md)
- [Commits](https://github.com/mout/mout/compare/v0.9.1...v1.2.4)

Updates `wiredep` from 2.2.2 to 4.0.0
- [Release notes](https://github.com/taptapship/wiredep/releases)
- [Commits](https://github.com/taptapship/wiredep/compare/v2.2.2...v4.0.0)

---
updated-dependencies:
- dependency-name: mout dependency-type: indirect
- dependency-name: wiredep dependency-type: direct:development ...

Signed-off-by: dependabot[bot] <support@github.com>