### PR TITLE
added proper context with this.html.find instead of using global jQu…

### DIFF
--- a/app/scripts/modeleditors/cfid/casefileitemdefinitioneditor.js
+++ b/app/scripts/modeleditors/cfid/casefileitemdefinitioneditor.js
@@ -161,8 +161,8 @@
 
         const defType = definition.definitionType;
 
-        $('.cfidefeditor .maincfidefdata input').val(definition.name);
-        $('.cfidefeditor .maincfidefdata select').val(defType);
+        this.html.find('.maincfidefdata input').val(definition.name);
+        this.html.find('.maincfidefdata select').val(defType);
         this.renderDefinitionTypeEditor();
     }
 


### PR DESCRIPTION
This bug caused improper information was rendered in CFID editor when switching between more than one open case model.