### PR TITLE
Show where used info in Deploy Case model form

### DIFF
--- a/app/scripts/elements/case.js
+++ b/app/scripts/elements/case.js
@@ -135,6 +135,13 @@
 
         const end = new Date();
         console.log('Case loaded in ' + ((end - now) / 1000) + ' seconds')
+
+        const urlQuery = window.location.hash.slice(1).split('?');
+        if (urlQuery.length > 1) {
+            if (urlQuery[1].startsWith('deploy=true')) {
+                this.deployForm.show();
+            }
+        }
     }
 
     /**

--- a/app/scripts/modeleditors/case/deploy.js
+++ b/app/scripts/modeleditors/case/deploy.js
@@ -19,6 +19,10 @@ class Deploy extends StandardForm {
         <button class="btn btn-default btnDeploy">Deploy</button>
     </div>
     <span class="deployed_timestamp"></span>
+    <div class="where_used_content">
+        <br/>
+        <div class="whereUsedContent"/>
+    </div>
     <div class="deploy_content">
         <label class="deployFormLabel"></label>
         <div class="codeMirrorSource deployFormContent" />
@@ -30,6 +34,14 @@ class Deploy extends StandardForm {
         this.html.find('.btnServerValidation').on('click', () => this.runServerValidation());
 
         this.codeMirrorCaseXML = CodeMirrorConfig.createXMLEditor(this.htmlContainer.find('.deployFormContent'));
+
+        const model = this.modelEditor.ide.repository.get(this.case.editor.fileName);
+        if (model.usage.length > 0) {
+            const modelRenderer = e => `<a href="./#${e.id}?deploy=true" title="Click to open the deploy form of ${e.id}">${e.name}</a>`;
+            const whereUsedCounter = `Used in ${model.usage.length} other model${model.usage.length == 1 ? '' : 's'}`;
+            const whereUsedModels = `${model.usage.map(modelRenderer).join(",&nbsp;&nbsp;")}`;
+            this.html.find('.whereUsedContent').html(whereUsedCounter + ": " + whereUsedModels);
+        }
     }
 
     _setDeployedTimestamp(text) {
@@ -52,7 +64,7 @@ class Deploy extends StandardForm {
 
     deploy() {
         // By logging the deploy action in a group, we can see in the console how many times the file has been deployed. UI only shows latest...
-        console.group("Deploying case file "+this.case.editor.fileName);
+        console.group("Deploying case file " + this.case.editor.fileName);
         $.get('/repository/deploy/' + this.case.editor.fileName)
             .done(data => {
                 const now = new Date().toISOString().replace('T', ' ').substring(0, 19);
@@ -65,12 +77,12 @@ class Deploy extends StandardForm {
                 console.groupEnd();
                 this._setDeployTextArea(data.responseText);
                 this._setDeployedTimestamp('');
-                this.case.editor.ide.danger('Deploy of CMMN model '+this.case.name+' failed');
+                this.case.editor.ide.danger('Deploy of CMMN model ' + this.case.name + ' failed');
             });
     }
 
     viewCMMN() {
-       this._setDeployTextArea('Fetching CMMN ...');
+        this._setDeployTextArea('Fetching CMMN ...');
         $.get('/repository/viewCMMN/' + this.case.editor.fileName)
             .done(data => this._setDeployTextArea((new XMLSerializer()).serializeToString(data)))
             .fail(data => this._setDeployTextArea(data.responseText));

--- a/app/scripts/repository/repositorybrowser.js
+++ b/app/scripts/repository/repositorybrowser.js
@@ -152,7 +152,8 @@ class RepositoryBrowser {
      */
     loadModelFromBrowserLocation() {
         // Splice: take "myMap/myModel.case" out of something like "http://localhost:2081/#myMap/myModel.case"
-        const fileName = window.location.hash.slice(1);
+        //  Skip anything that is behind the optional question mark
+        const fileName = window.location.hash.slice(1).split('?')[0];
         this.currentFileName = fileName;
         this.refreshAccordionStatus();
 

--- a/app/styles/modeleditors/case/deploy.css
+++ b/app/styles/modeleditors/case/deploy.css
@@ -20,7 +20,7 @@
 
 .deploy_content {
     position:absolute;
-    top:45px;
+    top:75px;
     bottom:0px;
     left:0px;
     right:0px;


### PR DESCRIPTION
- Where used info Renders only when model is used in others.
- Where used info is generated with an URL and a link to open the deploy form of the other model where current model is used.
- The repository browser now accepts an optional URL search parameter (e.g. #model.case?deploy=true) to open the deploy form immediately after opening the model.