### PR TITLE
Read entire contents when listing files

### DIFF
--- a/app/scripts/repository/metadata.js
+++ b/app/scripts/repository/metadata.js
@@ -5,5 +5,6 @@ class Metadata {
         this.usage = json.usage;
         this.error = json.error;
         this.type = json.type;
+        this.serverContent = json.content;
     }
 }

--- a/app/scripts/repository/serverfile.js
+++ b/app/scripts/repository/serverfile.js
@@ -69,6 +69,9 @@ class ServerFile {
         } else {
             this.clear();
         }
+        if (serverMetadata.serverContent) {
+            this.source = serverMetadata.serverContent;
+        }
         this.lastModified = serverMetadata.lastModified;
     }
 

--- a/server/repository/repository-router.js
+++ b/server/repository/repository-router.js
@@ -15,7 +15,7 @@ const xmlParser = bodyParser.text({ type: 'application/xml', limit: '50mb' });
  * Returns the repository contents by name, last modified timestamp and usage information
  */
 router.get('/list', function (req, res, next) {
-    const list = repository.list();
+    const list = repository.contents();
     res.json(list);
 });
 
@@ -67,7 +67,7 @@ router.put('/rename/:fileName', xmlParser, function (req, res, next) {
         console.log(`RENAME /${fileName} to /${newFileName}`);
         repository.rename(fileName, newFileName);
 
-        const list = repository.list();
+        const list = repository.contents();
         res.json(list);
     } catch (err) {
         console.error(err);


### PR DESCRIPTION
Saves roundtrips. List call is a bit larger, around up to 1Mb for CMMN-Test-Framework contents, consisting of 190 models...