### PR TITLE
Do not warn for contextRef on 'true' and 'false'

### DIFF
--- a/app/scripts/elements/planitemview.js
+++ b/app/scripts/elements/planitemview.js
@@ -141,7 +141,7 @@ class PlanItemView extends CMMNElement {
             this.raiseValidationIssue(24, [this.name, this.case.name, ruleType, 'rule expression']);
         }
 
-        if (rule && !rule.contextRef) {
+        if (rule && !rule.contextRef && rule.body !== 'true' && rule.body !== 'false') {
             this.raiseValidationIssue(39, [this.name, this.case.name, ruleType, 'context (case file item)']);
         }
     }


### PR DESCRIPTION
Many repetition rules are simply "true", and there is no need to suggest setting the case file context for it.