### PR TITLE
Increase numbers to avoid unexpected migrations

### DIFF
--- a/app/scripts/definition/typecounter.js
+++ b/app/scripts/definition/typecounter.js
@@ -13,16 +13,12 @@ class TypeCounter {
 
     getNextIdOfType(constructor) {
         const prefix = (constructor.prefix ? constructor.prefix + '_' : '') + this.guid + '_';
-        let counter = 0;
-        while (this.modelDefinition.getElement(prefix+counter) !== undefined) counter++;
-        return prefix + counter;
+        return this.getNextCounter('id', prefix);
     }
 
     getNextNameOfType(constructor) {
         const prefix = this.getTypeName(constructor) + '_';
-        let counter = 0;
-        while (this.modelDefinition.elements.find(element => element.name == prefix+counter) !== undefined) counter++;
-        return prefix + counter;
+        return this.getNextCounter('name', prefix);
     }
 
     getTypeName(constructor) {
@@ -32,5 +28,16 @@ class TypeCounter {
         } else {
             return constructor.name;
         }
+    }
+
+    getNextCounter(type, prefix) {
+        // console.warn("Calculating next " + type +" of " + prefix)
+        const elementsWithPrefix = this.modelDefinition.elements.filter(element => typeof(element[type]) === 'string' && element[type].indexOf(prefix) == 0).map(element => element[type]);
+        // console.log("Found " + elementsWithPrefix.length +" elements where " + type +" contains prefix " + prefix + ": [" + elementsWithPrefix.join(', ') + "]")
+        const counters = elementsWithPrefix.map(prefixedValue => new Number(prefixedValue.replace(prefix, ''))).filter(number => !Number.isNaN(number));
+        // console.log("Found " + counters.length +" numbers [" + counters.join(", ") +"]")
+        const sorted = counters.sort((a,b) => a > b ? 1 : a == b ? 0 : -1);
+        // console.log("Sorted numbers:  [" + sorted.join(", ") +"]")
+        return prefix + (sorted.length === 0 ? 0 : sorted[sorted.length - 1].valueOf() + 1);
     }
 }


### PR DESCRIPTION
Instead of reusing "free" numbers for a certain type now always generated a new number, larger than any existing one. This way we can avoid that someone wants to migrate a definition by adjusting an existing model with the following scenario:
- remove one task, add an entirely different new task.

With reusing the free number, the case engine assumes the existing task is being migrated, instead of dropped and a new one created. To understand the background of such a scenario seems somewhat too much of a challenge ...