### PR TITLE
Refactor migration to fix #136

### DIFF
--- a/src/repository/definition/cmmn/casedefinition.js
+++ b/src/repository/definition/cmmn/casedefinition.js
@@ -2,12 +2,12 @@ import CaseFile from "@repository/serverfile/casefile";
 import TextAnnotationDefinition from "../artifact/textannotation";
 import CMMNElementDefinition from "../cmmnelementdefinition";
 import Dimensions from "../dimensions/dimensions";
+import Migrator from "../migration/cmmn/migrator";
 import ModelDefinition from "../modeldefinition";
 import CaseFileDefinition from "./casefile/casefiledefinition";
 import CasePlanDefinition from "./caseplan/caseplandefinition";
 import CaseTeamDefinition from "./caseteam/caseteamdefinition";
 import CaseParameterDefinition from "./contract/caseparameterdefinition";
-import Migrator from "./migrator";
 import StartCaseSchemaDefinition from "./startcaseschemadefinition";
 
 export default class CaseDefinition extends ModelDefinition {

--- a/src/repository/definition/cmmn/caseteam/caseteamdefinition.js
+++ b/src/repository/definition/cmmn/caseteam/caseteamdefinition.js
@@ -1,4 +1,3 @@
-import XML from "@util/xml";
 import UnnamedCMMNElementDefinition from "../../unnamedcmmnelementdefinition";
 import CaseRoleDefinition from "./caseroledefinition";
 
@@ -7,43 +6,12 @@ export default class CaseTeamDefinition extends UnnamedCMMNElementDefinition {
         super(importNode, caseDefinition, parent);
         /** @type {Array<CaseRoleDefinition>} */
         this.roles = this.parseElements('role', CaseRoleDefinition);
-        if (this.roles.length == 0 && this.name) {
-            // This means we bumped into a CMMN 1.0 role
-
-            // Since this is single role, the (optional) description is already converted to documentation, but remove that
-            //  and let the role conversion create it instead
-            if (this.documentation.text) this.documentation.text = '';
-            this.importNode.appendChild(CaseTeamDefinition.convertRoleDefinition(importNode));
-            this.roles = this.parseElements('role', CaseRoleDefinition);
-            this.caseDefinition.migrated('Converting CMMN1.0 role');
-        }
         // Clear our name and id element, so that caseteam definition is not accidentally found as a case role element
         this.name = undefined;
         this.id = undefined;
     }
 
-    /**
-     * 
-     * @param {Element} element 
-     */
-    static convertRoleDefinition(element) {
-        const clearAttribute = name => {
-            const value = element.getAttribute(name) || ''; // Avoid reading null values from attributes
-            element.removeAttribute(name); // And clear the attribute
-            return value;
-        }
-
-        const id = clearAttribute('id');
-        const name = clearAttribute('name');
-        const description = clearAttribute('description');
-        const optionalDescription = name !== description ? `description="${description}"` : '';
-        return XML.loadXMLString(`<role id="${id}" name="${name}" ${optionalDescription}/>`).documentElement;
-    }
-
     createExportNode(parentNode) {
-        // Only export if there are actual roles defined in this case
-        if (this.roles.length) {
-            super.createExportNode(parentNode, 'caseRoles', 'roles');
-        }
+        super.createExportNode(parentNode, 'caseRoles', 'roles');
     }
 }

--- a/src/repository/definition/migration/cmmn/migrator.js
+++ b/src/repository/definition/migration/cmmn/migrator.js
@@ -1,0 +1,38 @@
+import XML from "@util/xml";
+import CaseDefinition from "../../cmmn/casedefinition";
+import CaseTeamMigrator from "./team/caseteammigrator";
+import SentryMigrator from "./plan/sentrymigrator";
+import CasePlanMigrator from "./plan/caseplanmigrator";
+
+export default class Migrator {
+    static updateXMLElement(definition) {
+        new Migrator(definition);
+    }
+
+    /**
+     * 
+     * @param {String} msg 
+     */
+    migrated(msg) {
+        this.definition.migrated(msg);
+    }
+
+    /**
+     * 
+     * @param {CaseDefinition} definition 
+     */
+    constructor(definition) {
+        this.definition = definition;
+        const teamMigrator = new CaseTeamMigrator(this);
+        const sentryMigrator = new SentryMigrator(this);
+        const planMigrator = new CasePlanMigrator(this);
+        if (teamMigrator.needsMigration() || sentryMigrator.needsMigration() || planMigrator.needsMigration()) {
+            console.group(`Migrating XML contents of ${this.definition.file.fileName} to the new format`);
+            teamMigrator.run();
+            sentryMigrator.run();
+            planMigrator.run();
+            console.groupEnd();
+        }
+    }
+}
+

--- a/src/repository/definition/migration/cmmn/plan/sentrymigrator.ts
+++ b/src/repository/definition/migration/cmmn/plan/sentrymigrator.ts
@@ -1,0 +1,31 @@
+import XML from "@util/xml";
+import Migrator from "../migrator";
+
+export default class SentryMigrator {
+    constructor(public migrator: Migrator) {}
+
+    needsMigration(): boolean {
+        return XML.allElements(XML.getChildByTagName(this.migrator.definition.importNode, 'sentry')).length > 0;
+    }
+
+    run() {
+        const importNode = this.migrator.definition.importNode;
+        const sentries = XML.getElementsByTagName(importNode, 'sentry');
+        if (sentries.length > 0) {
+            console.groupCollapsed("Converting " + sentries.length + " sentries in case plan of " + this.migrator.definition.file.fileName);
+            const allElements = XML.allElements(importNode);
+            sentries.forEach(sentry => {
+                const id = sentry.getAttribute('id');
+                const criterion = allElements.find(element => !element.getAttribute('sourceRef') && element.getAttribute('sentryRef') === id);
+                if (criterion) {
+                    sentry.childNodes.forEach(node => criterion.appendChild(node.cloneNode(true)));
+                    sentry.parentElement && sentry.parentElement.removeChild(sentry);
+                } else {
+                    console.error(`Skipping migration of sentry ${id} because there is no criterion referring to it`);
+                }
+            });
+            this.migrator.migrated(`Merged <sentry> elements with their corresponding definitions, so now we have only <entryCriterion>, <exitCriterion> and <reactivateCriterion>`);
+            console.groupEnd();
+        }
+    }
+}

--- a/src/repository/definition/migration/cmmn/team/caseteammigrator.ts
+++ b/src/repository/definition/migration/cmmn/team/caseteammigrator.ts
@@ -1,0 +1,68 @@
+import XML from "@util/xml";
+import Migrator from "../migrator";
+
+export default class CaseTeamMigrator {
+    roleElements: Element[];
+
+    constructor(public migrator: Migrator) {
+        const importNode = this.migrator.definition.importNode;
+        this.roleElements = XML.getChildrenByTagName(importNode, 'caseRoles');
+        if (this.roleElements.length === 0) {            
+            // Make sure we always have a CaseTeam element
+            importNode.appendChild(importNode.ownerDocument.createElement('caseRoles'));
+        }
+    }
+
+    needsMigration(): boolean {
+        const classicRoles = XML.getChildrenByTagName(this.migrator.definition.importNode, 'caseRoles'); // More than 1 means CMMN 1.0 style roles.
+        if (classicRoles.length === 0) {
+            // No roles defined, so also we're safe here.
+            return false;
+        } else if (classicRoles.length === 1) {
+            // We found 1 role tag. It can be both CMMN 1.0 and 1.1. If it is 1.0, it will have a name attribute...
+            const name = classicRoles[0].getAttribute('name');
+            return name !== null && name.trim().length > 0;
+        } else {
+            // More than 1 role tag means we CMMN1.0 and need to migrate
+            return true;
+        }
+    }
+
+    run() {
+        const importNode = this.migrator.definition.importNode;
+        // CMMN 1.0 format, we must migrate. Also, if roles.length == 0, then we should create an element to avoid nullpointers.
+        //  Note: if there is only 1 caseRoles tag it can be both CMMN1.0 or CMMN1.1;
+        //  CaseTeamDefinition class will do the check if additional migration is required.
+        if (this.roleElements.length) {
+            this.migrator.migrated(`Converting ${this.roleElements.length} CMMN1.0 roles`);
+        }
+
+
+        // Create a new element
+        const caseTeamElement = importNode.ownerDocument.createElement('caseRoles');
+        importNode.appendChild(caseTeamElement);
+
+        this.roleElements.forEach(role => {
+            role.parentElement && role.parentElement.removeChild(role);
+            caseTeamElement.appendChild(this.convertRoleDefinition(role));
+        });
+    }
+
+    /**
+     * 
+     * @param {Element} element 
+     */
+    convertRoleDefinition(element: Element) {
+        const clearAttribute = (name: string) => {
+            const value = element.getAttribute(name) || ''; // Avoid reading null values from attributes
+            element.removeAttribute(name); // And clear the attribute
+            return value;
+        }
+
+        const id = clearAttribute('id');
+        const name = clearAttribute('name');
+        const description = clearAttribute('description');
+        const optionalDescription = name !== description ? `description="${description}"` : '';
+        return XML.loadXMLString(`<role id="${id}" name="${name}" ${optionalDescription}/>`).documentElement;
+    }
+}


### PR DESCRIPTION
Now also always export the <caseRoles /> tag, even if it is empty - but this only happens when there is a semantic change to the model

Fixes #136