### PR TITLE
Fix showing parameter names in task mappings editor

### DIFF
--- a/src/repository/definition/cmmn/caseplan/task/workflow/cafienneworkflowdefinition.ts
+++ b/src/repository/definition/cmmn/caseplan/task/workflow/cafienneworkflowdefinition.ts
@@ -23,6 +23,10 @@ export default class CafienneWorkflowDefinition extends CafienneImplementationDe
         this.dueDate = this.parseElement((DueDateDefinition as any).TAG, DueDateDefinition);
     }
 
+    resolvedExternalReferences() {
+        this.task.bindImplementation();
+    }
+
     get inputs() {
         return this.task.inputs;
     }


### PR DESCRIPTION
Fixed by adding the callback on the task when the references in the workflowdefinition have been resolved.