### PR TITLE
Use alpine docker image iso slim and upgrade to node 23.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Create runtime image
-FROM node:22.14.0-slim
+FROM node:23.11-alpine
 
 # Switch workdir - this specific directory is used in standard configurations of e.g. getting-started to mount the repository folder
 WORKDIR /usr/src/app


### PR DESCRIPTION
Use the smaller alpine image iso slim:
<img width="749" alt="image" src="https://github.com/user-attachments/assets/818e3cc9-3dc4-438d-b663-ab44029beaff" />

Also upgrade to node 23.11 to have fewer vulnerabilities.

Alpine vs Slim: https://forums.docker.com/t/differences-between-standard-docker-images-and-alpine-slim-versions/134973/2
